### PR TITLE
Reuse.software compliance

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,0 +1,13 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: asql
+Source: https://github.com/cutelyst/asql.git
+
+# The GitHub administrative files, as well as .gitignore,
+# are purely descriptive and have no copyrightable content.
+# Put them under CC0-1.0 (as a "shut up" for the tool).
+# Since there must be a copyright statement as well,
+# use the text "no" for that.
+Files: .gitignore .github/*
+License: CC0-1.0
+Copyright: no
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+# SPDX-License-Identifier: MIT
+
 cmake_minimum_required(VERSION 3.5)
 project(libasql VERSION 0.19.0 LANGUAGES CXX)
 

--- a/LICENSES/CC0-1.0.txt
+++ b/LICENSES/CC0-1.0.txt
@@ -1,0 +1,119 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES
+NOT PROVIDE LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE
+AN ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS INFORMATION
+ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES REGARDING THE USE
+OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED HEREUNDER, AND DISCLAIMS
+LIABILITY FOR DAMAGES RESULTING FROM THE USE OF THIS DOCUMENT OR THE INFORMATION
+OR WORKS PROVIDED HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer exclusive
+Copyright and Related Rights (defined below) upon the creator and subsequent
+owner(s) (each and all, an "owner") of an original work of authorship and/or
+a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for the
+purpose of contributing to a commons of creative, cultural and scientific
+works ("Commons") that the public can reliably and without fear of later claims
+of infringement build upon, modify, incorporate in other works, reuse and
+redistribute as freely as possible in any form whatsoever and for any purposes,
+including without limitation commercial purposes. These owners may contribute
+to the Commons to promote the ideal of a free culture and the further production
+of creative, cultural and scientific works, or to gain reputation or greater
+distribution for their Work in part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any expectation
+of additional consideration or compensation, the person associating CC0 with
+a Work (the "Affirmer"), to the extent that he or she is an owner of Copyright
+and Related Rights in the Work, voluntarily elects to apply CC0 to the Work
+and publicly distribute the Work under its terms, with knowledge of his or
+her Copyright and Related Rights in the Work and the meaning and intended
+legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be protected
+by copyright and related or neighboring rights ("Copyright and Related Rights").
+Copyright and Related Rights include, but are not limited to, the following:
+
+i. the right to reproduce, adapt, distribute, perform, display, communicate,
+and translate a Work;
+
+      ii. moral rights retained by the original author(s) and/or performer(s);
+
+iii. publicity and privacy rights pertaining to a person's image or likeness
+depicted in a Work;
+
+iv. rights protecting against unfair competition in regards to a Work, subject
+to the limitations in paragraph 4(a), below;
+
+v. rights protecting the extraction, dissemination, use and reuse of data
+in a Work;
+
+vi. database rights (such as those arising under Directive 96/9/EC of the
+European Parliament and of the Council of 11 March 1996 on the legal protection
+of databases, and under any national implementation thereof, including any
+amended or successor version of such directive); and
+
+vii. other similar, equivalent or corresponding rights throughout the world
+based on applicable law or treaty, and any national implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention of,
+applicable law, Affirmer hereby overtly, fully, permanently, irrevocably and
+unconditionally waives, abandons, and surrenders all of Affirmer's Copyright
+and Related Rights and associated claims and causes of action, whether now
+known or unknown (including existing as well as future claims and causes of
+action), in the Work (i) in all territories worldwide, (ii) for the maximum
+duration provided by applicable law or treaty (including future time extensions),
+(iii) in any current or future medium and for any number of copies, and (iv)
+for any purpose whatsoever, including without limitation commercial, advertising
+or promotional purposes (the "Waiver"). Affirmer makes the Waiver for the
+benefit of each member of the public at large and to the detriment of Affirmer's
+heirs and successors, fully intending that such Waiver shall not be subject
+to revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason be
+judged legally invalid or ineffective under applicable law, then the Waiver
+shall be preserved to the maximum extent permitted taking into account Affirmer's
+express Statement of Purpose. In addition, to the extent the Waiver is so
+judged Affirmer hereby grants to each affected person a royalty-free, non
+transferable, non sublicensable, non exclusive, irrevocable and unconditional
+license to exercise Affirmer's Copyright and Related Rights in the Work (i)
+in all territories worldwide, (ii) for the maximum duration provided by applicable
+law or treaty (including future time extensions), (iii) in any current or
+future medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional purposes
+(the "License"). The License shall be deemed effective as of the date CC0
+was applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder of
+the License, and in such case Affirmer hereby affirms that he or she will
+not (i) exercise any of his or her remaining Copyright and Related Rights
+in the Work or (ii) assert any associated claims and causes of action with
+respect to the Work, in either case contrary to Affirmer's express Statement
+of Purpose.
+
+   4. Limitations and Disclaimers.
+
+a. No trademark or patent rights held by Affirmer are waived, abandoned, surrendered,
+licensed or otherwise affected by this document.
+
+b. Affirmer offers the Work as-is and makes no representations or warranties
+of any kind concerning the Work, express, implied, statutory or otherwise,
+including without limitation warranties of title, merchantability, fitness
+for a particular purpose, non infringement, or the absence of latent or other
+defects, accuracy, or the present or absence of errors, whether or not discoverable,
+all to the greatest extent permissible under applicable law.
+
+c. Affirmer disclaims responsibility for clearing rights of other persons
+that may apply to the Work or any use thereof, including without limitation
+any person's Copyright and Related Rights in the Work. Further, Affirmer disclaims
+responsibility for obtaining any necessary consents, permissions or other
+rights required for any use of the Work.
+
+d. Affirmer understands and acknowledges that Creative Commons is not a party
+to this document and has no duty or obligation with respect to this CC0 or
+use of the Work.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Cutelyst
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<!-- SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+     SPDX-License-Identifier: MIT
+-->
+
 # ASql
 Qt Async Sql library
 

--- a/cmake/modules/CPackConfig.cmake
+++ b/cmake/modules/CPackConfig.cmake
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+# SPDX-License-Identifier: MIT
+
 set(CPACK_PACKAGE_VENDOR "Daniel Nicoletti")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Async Sql Qt library.")
 set(CPACK_RESOURCE_FILE_README "${CMAKE_SOURCE_DIR}/README.md")

--- a/cmake/modules/asqlqt5-config-version.cmake.in
+++ b/cmake/modules/asqlqt5-config-version.cmake.in
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+# SPDX-License-Identifier: MIT
+
 SET(PACKAGE_VERSION @PROJECT_VERSION@)
 IF (PACKAGE_FIND_VERSION VERSION_EQUAL PACKAGE_VERSION)
   SET(PACKAGE_VERSION_EXACT "true")

--- a/cmake/modules/asqlqt5-config.cmake.in
+++ b/cmake/modules/asqlqt5-config.cmake.in
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+# SPDX-License-Identifier: MIT
+
 # - Config information for ASql
 # This file defines:
 #

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+# SPDX-License-Identifier: MIT
+
 add_subdirectory(async1)

--- a/demos/async1/CMakeLists.txt
+++ b/demos/async1/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+# SPDX-License-Identifier: MIT
+
 add_executable(async1 async1.cpp)
 target_link_libraries(async1
     ASqlQt5::Core

--- a/demos/async1/async1.cpp
+++ b/demos/async1/async1.cpp
@@ -1,3 +1,8 @@
+/* 
+ * SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
 #include <QCoreApplication>
 #include <QLoggingCategory>
 

--- a/demos/async1/dbscope.cpp
+++ b/demos/async1/dbscope.cpp
@@ -1,3 +1,8 @@
+/* 
+ * SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
 #include <QCoreApplication>
 #include <QLoggingCategory>
 

--- a/demos/async1/deleter.cpp
+++ b/demos/async1/deleter.cpp
@@ -1,3 +1,8 @@
+/* 
+ * SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
 #include <QCoreApplication>
 #include <QLoggingCategory>
 

--- a/demos/async1/prepared.cpp
+++ b/demos/async1/prepared.cpp
@@ -1,3 +1,8 @@
+/* 
+ * SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
 #include <QCoreApplication>
 #include <QLoggingCategory>
 #include <QElapsedTimer>

--- a/demos/async1/transactions.cpp
+++ b/demos/async1/transactions.cpp
@@ -1,3 +1,8 @@
+/* 
+ * SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
 #include <QCoreApplication>
 #include <QLoggingCategory>
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+# SPDX-License-Identifier: MIT
+
 set(asql_SRC
     adatabase_p.h
     adatabase.cpp

--- a/src/acache.cpp
+++ b/src/acache.cpp
@@ -1,3 +1,8 @@
+/* 
+ * SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
 #include "acache.h"
 #include "adatabase.h"
 #include "aresult.h"

--- a/src/acache.h
+++ b/src/acache.h
@@ -1,3 +1,8 @@
+/* 
+ * SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef ACACHE_H
 #define ACACHE_H
 

--- a/src/adatabase.cpp
+++ b/src/adatabase.cpp
@@ -1,3 +1,8 @@
+/* 
+ * SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
 #include "adatabase.h"
 #include "adatabase_p.h"
 

--- a/src/adatabase.h
+++ b/src/adatabase.h
@@ -1,3 +1,8 @@
+/* 
+ * SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef ADATABASE_H
 #define ADATABASE_H
 

--- a/src/adatabase_p.h
+++ b/src/adatabase_p.h
@@ -1,3 +1,8 @@
+/* 
+ * SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
 #include "adatabase.h"
 
 #include "adriver.h"

--- a/src/adriver.cpp
+++ b/src/adriver.cpp
@@ -1,3 +1,8 @@
+/* 
+ * SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
 #include "adriver.h"
 #include "aresult.h"
 

--- a/src/adriver.h
+++ b/src/adriver.h
@@ -1,3 +1,8 @@
+/* 
+ * SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef ADRIVER_H
 #define ADRIVER_H
 

--- a/src/adriverpg.cpp
+++ b/src/adriverpg.cpp
@@ -1,3 +1,8 @@
+/* 
+ * SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
 #include "adriverpg.h"
 
 #include "aresult.h"

--- a/src/adriverpg.h
+++ b/src/adriverpg.h
@@ -1,3 +1,8 @@
+/* 
+ * SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef ADRIVERPG_H
 #define ADRIVERPG_H
 

--- a/src/amigrations.cpp
+++ b/src/amigrations.cpp
@@ -1,3 +1,8 @@
+/* 
+ * SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
 #include "amigrations.h"
 #include "aresult.h"
 #include "atransaction.h"

--- a/src/amigrations.h
+++ b/src/amigrations.h
@@ -1,3 +1,8 @@
+/* 
+ * SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef AMIGRATIONS_H
 #define AMIGRATIONS_H
 

--- a/src/apool.cpp
+++ b/src/apool.cpp
@@ -1,3 +1,8 @@
+/* 
+ * SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
 #include "apool.h"
 #include "adatabase_p.h"
 

--- a/src/apool.h
+++ b/src/apool.h
@@ -1,3 +1,8 @@
+/* 
+ * SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef APOOL_H
 #define APOOL_H
 

--- a/src/apreparedquery.cpp
+++ b/src/apreparedquery.cpp
@@ -1,3 +1,8 @@
+/* 
+ * SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
 #include "apreparedquery.h"
 
 #include <QLoggingCategory>

--- a/src/apreparedquery.h
+++ b/src/apreparedquery.h
@@ -1,3 +1,8 @@
+/* 
+ * SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef APREPAREDQUERY_H
 #define APREPAREDQUERY_H
 

--- a/src/aqsqlexports.h
+++ b/src/aqsqlexports.h
@@ -1,3 +1,8 @@
+/* 
+ * SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef ASQL_EXPORT_H
 #define ASQL_EXPORT_H
 

--- a/src/aresult.cpp
+++ b/src/aresult.cpp
@@ -1,3 +1,8 @@
+/* 
+ * SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
 #include "aresult.h"
 
 #include <QJsonArray>

--- a/src/aresult.h
+++ b/src/aresult.h
@@ -1,3 +1,8 @@
+/* 
+ * SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef ARESULT_H
 #define ARESULT_H
 

--- a/src/asql-qt5.pc.in
+++ b/src/asql-qt5.pc.in
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+# SPDX-License-Identifier: MIT
+
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 libdir=@CMAKE_INSTALL_FULL_LIBDIR@

--- a/src/asql_migration.cpp
+++ b/src/asql_migration.cpp
@@ -1,3 +1,8 @@
+/* 
+ * SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
 #include <QCoreApplication>
 #include <QCommandLineParser>
 #include <QLoggingCategory>

--- a/src/atransaction.cpp
+++ b/src/atransaction.cpp
@@ -1,3 +1,8 @@
+/* 
+ * SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
 #include "atransaction.h"
 
 #include <QLoggingCategory>

--- a/src/atransaction.h
+++ b/src/atransaction.h
@@ -1,3 +1,8 @@
+/* 
+ * SPDX-FileCopyrightText: (C) 2020 Daniel Nicoletti <dantti12@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
 #ifndef ATRANSACTION_H
 #define ATRANSACTION_H
 


### PR DESCRIPTION
https://reuse.software/ is a way of annotating (Open Source) software so that the license is immediately clear, everywhere, using machine-readable tags and ensuring that all files in a repo are licensed.

This branch pushes those tags into all the asql files. It touches every file in the repo, sorry :cry: Invasive changes are:
 - moving the MIT license into LICENSES/ (this is basically mandated by the tools used)
 - adding a copyright statement for you (dantti) to every file in the repo

The REUSE howto is worth reading, it gives an overview and some context. The tool is also overly pedantic and sometimes annoying (like needing to license your .gitignore) and I certainly Have Opinions about that but the patches in this branch satisfy the tool, and hence the lawyers too.