### PR TITLE
Remove usage of QStringView in ACache

### DIFF
--- a/src/acache.h
+++ b/src/acache.h
@@ -27,7 +27,6 @@ public:
     virtual ~ACache();
 
     void setDatabasePool(const QString &poolName);
-    void setDatabasePool(QStringView poolName);
     void setDatabase(const ADatabase &db);
 
     /*!
@@ -36,9 +35,9 @@ public:
      * \param params
      * \return
      */
-    bool clear(QStringView query, const QVariantList &params = {});
+    bool clear(const QString &query, const QVariantList &params = {});
     bool expire(std::chrono::milliseconds maxAge,
-                QStringView query,
+                const QString &query,
                 const QVariantList &params = {});
     int expireAll(std::chrono::milliseconds maxAge);
 
@@ -48,28 +47,16 @@ public:
      */
     [[nodiscard]] int size() const;
 
-    AExpectedResult coExec(QStringView query, QObject *receiver = nullptr);
+    AExpectedResult coExec(const QString &query, QObject *receiver = nullptr);
     AExpectedResult
-        coExec(QStringView query, const QVariantList &args, QObject *receiver = nullptr);
-    AExpectedResult coExecExpiring(QStringView query,
+        coExec(const QString &query, const QVariantList &args, QObject *receiver = nullptr);
+    AExpectedResult coExecExpiring(const QString &query,
                                    std::chrono::milliseconds maxAge,
                                    QObject *receiver = nullptr);
-    AExpectedResult coExecExpiring(QStringView query,
+    AExpectedResult coExecExpiring(const QString &query,
                                    std::chrono::milliseconds maxAge,
                                    const QVariantList &args,
                                    QObject *receiver = nullptr);
-
-    void exec(QStringView query, QObject *receiver, AResultFn cb);
-    void exec(QStringView query, const QVariantList &args, QObject *receiver, AResultFn cb);
-    void execExpiring(QStringView query,
-                      std::chrono::milliseconds maxAge,
-                      QObject *receiver,
-                      AResultFn cb);
-    void execExpiring(QStringView query,
-                      std::chrono::milliseconds maxAge,
-                      const QVariantList &args,
-                      QObject *receiver,
-                      AResultFn cb);
 
     void exec(const QString &query, QObject *receiver, AResultFn cb);
     void exec(const QString &query, const QVariantList &args, QObject *receiver, AResultFn cb);


### PR DESCRIPTION
For some unknown reason sometimes when QMultiHash<QStringView is used and we try to find(query) an entry the iterator returned is not the latest inserted, and our while loop to find the matching ACacheValue.args will not find it and silently ignore the return causing the caller to "leak" as it's stuck untill the cache is cleaned.

With QString that does not happen, and eventually in Qt 6.8 we can use the view to do lookups.