### PR TITLE
Fix missing include for QJsonArray

### DIFF
--- a/src/ADriverOdbc.cpp
+++ b/src/ADriverOdbc.cpp
@@ -6,6 +6,7 @@
 
 #include <QCborValue>
 #include <QDateTime>
+#include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonValue>


### PR DESCRIPTION
g++-14 14.3.0 on openSUSE Leap 15.6 complains about incomplete type QJsonArray in ADriverOdbc. This fixes the error by adding the missing include.